### PR TITLE
Update brew installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A macOS utility that helps reduce distraction by dimming your inactive noise
 #### Using Homebrew
 
 ```
-brew cask install blurred
+brew install --cask blurred
 ```
 
 #### Manual download


### PR DESCRIPTION
As of [Homebrew 2.6.0](https://brew.sh/2020/12/01/homebrew-2.6.0/), `brew cask install` is deprecated in favor of `brew install --cask`
