### PR TITLE
Update homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A macOS utility that helps reduce distraction by dimming your inactive noise
 #### Using Homebrew
 
 ```
-brew --cask install blurred
+brew install --cask blurred
 ```
 
 #### Manual download

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A macOS utility that helps reduce distraction by dimming your inactive noise
 #### Using Homebrew
 
 ```
-brew cask install blurred
+brew --cask install blurred
 ```
 
 #### Manual download


### PR DESCRIPTION
#### What's this PR do?

Update homebrew install instructions. Previous one causing erros:

`Error: brew cask is no longer a brew command. Use brew <command> --cask instead.`
