### PR TITLE
use updated brew cask command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A macOS utility that helps reduce distraction by dimming your inactive noise
 #### Using Homebrew
 
 ```
-brew cask install blurred
+brew install --cask blurred
 ```
 
 #### Manual download


### PR DESCRIPTION
#### What's this PR do?

- [x] Updates brew install command to work with latest `homebrew`

#### Any background context you want to provide? (if appropriate)

```bash
brew cask install blurred
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```

So we need to use: `brew install --cask blurred` instead. and it works:
```bash
brew install --cask blurred
==> Caveats
blurred is built for Intel macOS and so requires Rosetta 2 to be installed.
You can install Rosetta 2 with:
  softwareupdate --install-rosetta --agree-to-license
Note that it is very difficult to remove Rosetta 2 once it is installed.

==> Downloading https://github.com/dwarvesf/blurred/releases/download/v1.2.0/Blurred.1.2.0.dmg
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/241799295/b6f5f080-b54a-11ea-9f5b-138509239
###################################################################################################################################### 100.0%
==> Installing Cask blurred
==> Moving App 'Blurred.app' to '/Applications/Blurred.app'
🍺  blurred was successfully installed!
```