### PR TITLE
Add Apple Silicon support for current Xcode builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ xcuserdata/
 ## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
 build/
 DerivedData/
+# BLURRED-2026: Ignore repo-local Xcode/SwiftPM caches used by current-Xcode build checks.
+.BuildCaches/
+.BuildHome/
+.DerivedData/
+.DerivedDataUniversal/
+.SourcePackages/
 *.moved-aside
 *.pbxuser
 !default.pbxuser

--- a/Blurred.xcodeproj/project.pbxproj
+++ b/Blurred.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 				0889D0FE23C4720E00E867FF /* Sources */,
 				0889D0FF23C4720E00E867FF /* Frameworks */,
 				0889D10023C4720E00E867FF /* Resources */,
+				BLRD260123C4720E00E867FF /* Strip Signing Detritus */,
 			);
 			buildRules = (
 			);
@@ -240,6 +241,7 @@
 				08FF678623A9156A00EACD58 /* Frameworks */,
 				08FF678723A9156A00EACD58 /* Resources */,
 				0889D11523C4739600E867FF /* CopyFiles */,
+				BLRD260223A9156A00EACD58 /* Strip Signing Detritus */,
 			);
 			buildRules = (
 			);
@@ -316,6 +318,47 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		BLRD260123C4720E00E867FF /* Strip Signing Detritus */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Strip Signing Detritus";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# BLURRED-2026: Remove file-provider metadata that current codesign rejects.\n/usr/bin/xattr -cr \"${TARGET_BUILD_DIR}/${WRAPPER_NAME}\" 2>/dev/null || true\n";
+		};
+		BLRD260223A9156A00EACD58 /* Strip Signing Detritus */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Strip Signing Detritus";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# BLURRED-2026: Remove file-provider metadata that current codesign rejects.\n/usr/bin/xattr -cr \"${TARGET_BUILD_DIR}/${WRAPPER_NAME}\" 2>/dev/null || true\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		0889D0FE23C4720E00E867FF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -390,10 +433,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = BlurredLauncher/BlurredLauncher.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = VGURA84Q2L;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
+				/* BLURRED-2026: Debug builds sign locally instead of requiring the old team certificate. */
 				INFOPLIST_FILE = BlurredLauncher/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -549,12 +594,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Blurred/Blurred.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = VGURA84Q2L;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
+				/* BLURRED-2026: Debug builds sign locally instead of requiring the old team certificate. */
 				INFOPLIST_FILE = Blurred/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Scripts/build-universal.sh
+++ b/Scripts/build-universal.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+# BLURRED-2026: Build one local Debug app containing both Apple Silicon and Intel slices.
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-"$ROOT_DIR/.DerivedDataUniversal"}"
+SOURCE_PACKAGES_PATH="${SOURCE_PACKAGES_PATH:-"$ROOT_DIR/.SourcePackages"}"
+
+# BLURRED-2026: Clear generated file-provider metadata before codesign sees the bundle.
+/usr/bin/xattr -cr "$DERIVED_DATA_PATH" 2>/dev/null || true
+
+# BLURRED-2026: Ask current Xcode for the standard macOS universal architecture pair.
+xcodebuild \
+  -project "$ROOT_DIR/Blurred.xcodeproj" \
+  -scheme Blurred \
+  -configuration Debug \
+  -destination generic/platform=macOS \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
+  -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+  ARCHS="arm64 x86_64" \
+  ONLY_ACTIVE_ARCH=NO \
+  build


### PR DESCRIPTION
This updates the macOS build setup so Blurred builds cleanly on current Xcode and Apple Silicon while preserving the app's existing behavior.

Changes:
- Allow Debug builds to sign locally without the old Mac Development team certificate
- Strip generated file-provider metadata before codesign so current Xcode builds cleanly
- Add a universal arm64/x86_64 Debug build script

Tested:
- xcodebuild Debug build succeeds on current Xcode
- Scripts/build-universal.sh produces a universal x86_64/arm64 app